### PR TITLE
Versión AGP del proyecto

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <value>
+      <entry key="app">
+        <State />
+      </entry>
+    </value>
+  </component>
+</project>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.0"
+agp = "8.2.0"
 kotlin = "1.9.0"
 coreKtx = "1.10.1"
 junit = "4.13.2"


### PR DESCRIPTION
### Descripción
- Modifico la version de AGP, para que sea compatible desde la versión de Android Studio Hedgehog | 2023.1.1

[Ver documentación ](https://developer.android.com/studio/releases?hl=es-419#android_gradle_plugin_and_android_studio_compatibility)

Importante!!!!
Antes de aprobar el cambio, verificar que en sus entornos funcione bien la versión, sino buscamos alguna que sea compatible para todos

