### PR TITLE
[Fix] Feedback screen constraints

### DIFF
--- a/app/src/main/java/com/devmob/alaya/domain/model/UsersProvider.kt
+++ b/app/src/main/java/com/devmob/alaya/domain/model/UsersProvider.kt
@@ -17,6 +17,7 @@ data class User (
     val patients: List<Patient>? = null
 ) : Serializable {
     constructor(name: String, surname: String, email: String, role: UserRole) : this(name, surname, "", email, role = role)
+    constructor() : this(name = "",surname = "",phone = "",email = "",image = R.drawable.logounologin,hour = "No tiene sesiones",role = UserRole.PATIENT)
 }
 
 

--- a/app/src/main/java/com/devmob/alaya/ui/components/BottomBarNavigation.kt
+++ b/app/src/main/java/com/devmob/alaya/ui/components/BottomBarNavigation.kt
@@ -41,6 +41,7 @@ import com.devmob.alaya.ui.theme.ColorPrimary
 import com.devmob.alaya.ui.theme.ColorTertiary
 import com.devmob.alaya.ui.theme.ColorText
 import com.devmob.alaya.ui.theme.ColorWhite
+import com.devmob.alaya.ui.theme.LightBlueColor
 import com.devmob.alaya.utils.NavUtils
 
 @Composable
@@ -66,7 +67,7 @@ fun BottomBarNavigation(items: List<ItemMenu>, navHostController: NavHostControl
                 colors = NavigationBarItemColors(
                     selectedIconColor = ColorTertiary, unselectedIconColor = ColorText, disabledIconColor = ColorText,
                     selectedTextColor = ColorTertiary, unselectedTextColor = ColorText, disabledTextColor = ColorText,
-                    selectedIndicatorColor = ColorTertiary,
+                    selectedIndicatorColor = LightBlueColor,
                 )
             )
         }

--- a/app/src/main/java/com/devmob/alaya/ui/screen/feedback/FeedbackScreen.kt
+++ b/app/src/main/java/com/devmob/alaya/ui/screen/feedback/FeedbackScreen.kt
@@ -11,10 +11,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.navigation.NavHostController
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
@@ -33,133 +35,160 @@ fun FeedbackScreen(
     feedbackType: FeedbackType,
     navController: NavHostController,
 ) {
-    Column(
+    ConstraintLayout(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.SpaceBetween
     ) {
-        when (feedbackType) {
-            FeedbackType.Felicitaciones -> {
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "¡Felicidades!",
-                    color = ColorText,
-                    style = MaterialTheme.typography.titleLarge.copy(fontSize = 50.sp),
-                    modifier = Modifier.padding(bottom = 16.dp)
-                )
-                Spacer(modifier = Modifier.height(8.dp))
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            when (feedbackType) {
+                FeedbackType.Felicitaciones -> {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(R.string.felicidades),
+                        color = ColorText,
+                        style = MaterialTheme.typography.titleLarge.copy(
+                            fontSize = 36.sp,
+                            fontWeight = Bold
+                        ),
+                        modifier = Modifier.padding(bottom = 16.dp)
+                    )
+                    Text(
+                        text = stringResource(R.string.lograste_superar_este_momento_segu_as),
+                        color = ColorText,
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.titleLarge.copy(fontSize = 30.sp),
+                        modifier = Modifier.padding(bottom = 10.dp)
+                    )
 
-                Text(
-                    text = "Lograste superar este momento. ¡Seguí así!",
-                    color = ColorText,
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.titleLarge.copy(fontSize = 30.sp),
-                    modifier = Modifier.padding(bottom = 10.dp)
-                )
-
-                val composition by rememberLottieComposition(spec = LottieCompositionSpec.RawRes(R.raw.feedback_congratulations_animation))
-                var isPlaying by remember {
-                    mutableStateOf(true)
-                }
-                val progress by animateLottieCompositionAsState(
-                    composition = composition,
-                    iterations = LottieConstants.IterateForever
-                )
-                LottieAnimation(
-                    composition = composition,
-                    progress = {
-                        progress
+                    val composition by rememberLottieComposition(
+                        spec = LottieCompositionSpec.RawRes(
+                            R.raw.feedback_congratulations_animation
+                        )
+                    )
+                    var isPlaying by remember {
+                        mutableStateOf(true)
                     }
-                )
-
-                Column {
-                    Button(
-                        text = "Registrar el episodio",
-                        onClick = {
-                            navController.navigate(NavUtils.PatientRoutes.CrisisRegistration.route)
+                    val progress by animateLottieCompositionAsState(
+                        composition = composition,
+                        iterations = LottieConstants.IterateForever
+                    )
+                    LottieAnimation(
+                        composition = composition,
+                        progress = {
+                            progress
                         },
-                        modifier = Modifier.fillMaxWidth(),
-                        style = ButtonStyle.Filled,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(1f)
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 16.dp)
+                    ) {
+                        Button(
+                            text = stringResource(R.string.registrar_el_episodio),
+                            onClick = {
+                                navController.navigate(NavUtils.PatientRoutes.CrisisRegistration.route)
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                            style = ButtonStyle.Filled,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Button(
+                            text = stringResource(R.string.registrar_el_episodio_m_s_tarde),
+                            onClick = {
+                                navController.navigate(NavUtils.PatientRoutes.Home.route) {
+                                    popUpTo(NavUtils.PatientRoutes.Home.route) {
+                                        inclusive = true
+                                    }
+                                    launchSingleTop = true
+                                }
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                            style = ButtonStyle.Outlined
+                        )
+                    }
+                }
+
+                FeedbackType.TodoVaAEstarBien -> {
+                    Text(
+                        text = stringResource(R.string.todo_va_a_estar_bien),
+                        color = ColorText,
+                        style = MaterialTheme.typography.titleLarge.copy(
+                            fontSize = 36.sp,
+                            fontWeight = Bold
+                        ),
+                        modifier = Modifier.padding(bottom = 17.dp)
                     )
                     Spacer(modifier = Modifier.height(8.dp))
-                    Button(
-                        text = "Registrar el episodio más tarde",
-                        onClick = {
-                            navController.navigate(NavUtils.PatientRoutes.Home.route) {
-                                popUpTo(NavUtils.PatientRoutes.Home.route) {
-                                    inclusive = true
-                                }
-                                launchSingleTop = true
-                            }
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                        style = ButtonStyle.Outlined
+
+                    Text(
+                        text = stringResource(R.string.est_bien_lo_importante_es_que_lo_intentaste),
+                        color = ColorText,
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.titleLarge.copy(fontSize = 30.sp),
+                        modifier = Modifier.padding(bottom = 10.dp)
                     )
-                }
-            }
-
-            FeedbackType.TodoVaAEstarBien -> {
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "¡Todo va a estar bien!",
-                    color = ColorText,
-                    fontSize = 35.sp,
-                    fontWeight = Bold,
-                    modifier = Modifier.padding(bottom = 17.dp)
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-
-                Text(
-                    text = "Está bien, lo importante es que lo intentaste",
-                    color = ColorText,
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.titleLarge.copy(fontSize = 30.sp),
-                    modifier = Modifier.padding(bottom = 10.dp)
-                )
-//
-                val composition by rememberLottieComposition(spec = LottieCompositionSpec.RawRes(R.raw.everything_will_be_fine_animation))
-                var isPlaying by remember {
-                    mutableStateOf(true)
-                }
-                val progress by animateLottieCompositionAsState(
-                    composition = composition,
-                    iterations = LottieConstants.IterateForever
-                )
-                LottieAnimation(
-                    composition = composition,
-                    progress = {
-                        progress
+                    val composition by rememberLottieComposition(
+                        spec = LottieCompositionSpec.RawRes(
+                            R.raw.everything_will_be_fine_animation
+                        )
+                    )
+                    var isPlaying by remember {
+                        mutableStateOf(true)
                     }
-                )
-
-                Column {
-                    Button(
-                        text = "Mi red de contención",
-                        onClick = {
-                            navController.navigate(NavUtils.PatientRoutes.ContainmentNetwork.route) {}
-                        },
-                        style = ButtonStyle.Filled,
-                        modifier = Modifier.fillMaxWidth(),
+                    val progress by animateLottieCompositionAsState(
+                        composition = composition,
+                        iterations = LottieConstants.IterateForever
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Button(
-                        onClick = {
-                            navController.navigate(NavUtils.PatientRoutes.Home.route) {
-                                popUpTo(NavUtils.PatientRoutes.Home.route) {
-                                    inclusive = true
+                    LottieAnimation(
+                        composition = composition,
+                        progress = {
+                            progress
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(1f)
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 16.dp)
+                    ) {
+                        Button(
+                            text = stringResource(R.string.mi_red_de_contenci_n),
+                            onClick = {
+                                navController.navigate(NavUtils.PatientRoutes.ContainmentNetwork.route) {}
+                            },
+                            style = ButtonStyle.Filled,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Button(
+                            onClick = {
+                                navController.navigate(NavUtils.PatientRoutes.Home.route) {
+                                    popUpTo(NavUtils.PatientRoutes.Home.route) {
+                                        inclusive = true
+                                    }
+                                    launchSingleTop = true
                                 }
-                                launchSingleTop = true
-                            }
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                        text = "Ir a inicio",
-                        style = ButtonStyle.Outlined
-                    )
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                            text = stringResource(R.string.ir_a_inicio),
+                            style = ButtonStyle.Outlined
+                        )
+                    }
                 }
             }
         }
     }
 }
-

--- a/app/src/main/java/com/devmob/alaya/ui/screen/patient_home/PatientHomeScreen.kt
+++ b/app/src/main/java/com/devmob/alaya/ui/screen/patient_home/PatientHomeScreen.kt
@@ -71,7 +71,7 @@ fun PatientHomeScreen(viewmodel: PatientHomeScreenViewmodel, navController: NavC
         )
 
         Text(
-            text = "Hola ${namePatient}, ${greetingMessage}!",
+            text = "Hola ${namePatient}, ¡${greetingMessage}!",
             fontSize = 32.sp,
             fontWeight = FontWeight.Bold,
             lineHeight = 32.sp,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,4 +63,12 @@
     <string name="title_modal_patient_invitation">Invitación de Vinculación</string>
     <string name="accept">Aceptar</string>
     <string name="decline">Rechazar</string>
+    <string name="mi_red_de_contenci_n">Mi red de contención</string>
+    <string name="ir_a_inicio">Ir a inicio</string>
+    <string name="est_bien_lo_importante_es_que_lo_intentaste">Está bien, lo importante es que lo intentaste</string>
+    <string name="todo_va_a_estar_bien">¡Todo va a estar bien!</string>
+    <string name="registrar_el_episodio_m_s_tarde">Registrar el episodio más tarde</string>
+    <string name="registrar_el_episodio">Registrar el episodio</string>
+    <string name="lograste_superar_este_momento_segu_as">Lograste superar este momento. ¡Seguí así!</string>
+    <string name="felicidades">¡Felicidades!</string>
 </resources>


### PR DESCRIPTION
- Se acomodaron los composables de las Feedback Screen (Probado en Pixel 8 y S22):

Feedback de "Felicitaciones":
Antes | Después
:-: | :-:
<image src="https://github.com/user-attachments/assets/1d99b251-ab69-498d-a68d-c67c7b01fc74" width=300/> | <image src="https://github.com/user-attachments/assets/3d417a16-2e8b-48b4-a008-6fa1743181ac" width=300/>

Feedback de "Todo va a estar bien":
Antes | Después
:-: | :-:
<image src="https://github.com/user-attachments/assets/47c65f51-ba71-4b77-9654-9088d2d6ac9e" width=300/> | <image src="https://github.com/user-attachments/assets/4e23fac9-45e4-4c17-975f-d3ecd7df6007" width=300/>

- Se cambió el color del item seleccionado en la Navigation Bar:

Antes | Después
:-: | :-:
<image src="https://github.com/user-attachments/assets/a525d0b7-17f1-4b2d-b28b-4bf39c2012e2" width=300/> | <image src="https://github.com/user-attachments/assets/89a581d9-281d-4348-9934-470662311e36" width=300/>

