### PR TITLE
Fix/Resumen de crisis

### DIFF
--- a/app/src/main/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationSummaryScreen.kt
+++ b/app/src/main/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationSummaryScreen.kt
@@ -429,9 +429,9 @@ fun SummaryItemCard(
 @Composable
 fun intensityFormatter(intensity: Intensity): String {
     return when (intensity) {
-        Intensity.LOW -> stringResource(R.string.intensity_low)
-        Intensity.MEDIUM -> stringResource(R.string.intensity_medium)
-        Intensity.HIGH -> stringResource(R.string.intensity_high)
+        Intensity.LOW -> "Intensidad: " + stringResource(R.string.intensity_low)
+        Intensity.MEDIUM -> "Intensidad: " + stringResource(R.string.intensity_medium)
+        Intensity.HIGH -> "Intensidad: " + stringResource(R.string.intensity_high)
     }
 }
 

--- a/app/src/main/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationSummaryScreen.kt
+++ b/app/src/main/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationSummaryScreen.kt
@@ -189,7 +189,7 @@ fun CrisisRegistrationSummaryScreen(
                                                         fontWeight = FontWeight.Bold,
                                                     )
                                                     Text(
-                                                        text = sensation.intensity.name,
+                                                        text = intensityFormatter(sensation.intensity),
                                                         fontSize = 19.sp,
                                                         color = ColorText,
                                                     )
@@ -234,8 +234,8 @@ fun CrisisRegistrationSummaryScreen(
                                                         fontWeight = FontWeight.Bold
                                                     )
                                                     Text(
-                                                        text = emotion.intensity.name,
-                                                        fontSize = 21.sp,
+                                                        text = intensityFormatter(emotion.intensity),
+                                                        fontSize = 19.sp,
                                                         color = ColorText
                                                     )
                                                 }
@@ -426,11 +426,12 @@ fun SummaryItemCard(
 /**
  * Formateador de Intensidad que devuelve como un String el tipo de intensidad que reciba por parametro
  */
-fun IntensityFormatter(intensity: Intensity): String {
+@Composable
+fun intensityFormatter(intensity: Intensity): String {
     return when (intensity) {
-        Intensity.LOW -> R.string.intensity_low.toString()
-        Intensity.MEDIUM -> R.string.intensity_medium.toString()
-        Intensity.HIGH -> R.string.intensity_high.toString()
+        Intensity.LOW -> stringResource(R.string.intensity_low)
+        Intensity.MEDIUM -> stringResource(R.string.intensity_medium)
+        Intensity.HIGH -> stringResource(R.string.intensity_high)
     }
 }
 


### PR DESCRIPTION
Se actualizo `CrisisRegistrationSummaryScreen.kt` para que formatee el string del enum y muestre bien la intensidad de la sensacion y emocion
Tambien se modifico el tamaño de la letra de esas mismas, para que sean iguales

![image](https://github.com/user-attachments/assets/63e2328d-1b26-44f8-93f1-0f892d40550f)

