### PR TITLE
[Fix] Tools flashing

### DIFF
--- a/app/src/main/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationScreen.kt
+++ b/app/src/main/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationScreen.kt
@@ -97,18 +97,6 @@ fun CrisisRegistrationScreen(
     LaunchedEffect(Unit) {
         viewModel.loadLastCrisisDetails()
     }
-    LaunchedEffect(screenState.value?.crisisDetails) {
-        val isCompleted = screenState.value?.crisisDetails?.completed == true
-        if (isCompleted) {
-            viewModel.cleanState()
-        }
-    }
-
-    GridElementsRepository.returnAvailableTools().let { list ->
-        for (tool in list) {
-            viewModel.addCrisisTool(tool)
-        }
-    }
 
     BackHandler {
         when(screenState.value?.currentStep){
@@ -152,7 +140,7 @@ fun CrisisRegistrationScreen(
                             top.linkTo(closeIcon.bottom, margin = 1.dp)
                         }
                 )
-                viewModel.screenState.value?.crisisDetails?.crisisTimeDetails?.let {
+                viewModel.screenState.value?.crisisDetails?.crisisTimeDetails?.let { time ->
                     DateTimePicker(
                         modifier = Modifier.constrainAs(datePickerComponent) {
                             start.linkTo(parent.start)
@@ -171,7 +159,7 @@ fun CrisisRegistrationScreen(
                         onEndTimeChange = { newTime ->
                             viewModel.updateEndDate(newTime)
                         },
-                        crisisTimeDetails = crisisTimeDetails
+                        crisisTimeDetails = time
                     )
                 }
             }
@@ -491,12 +479,11 @@ fun CrisisRegistrationScreen(
                             onClick = {
                                 if (isSelected) {
                                     selectedTools = selectedTools - tool.name
-                                    viewModel.selectedTools.remove(tool.id)
+                                    viewModel.unselectCrisisTool(tool)
                                 } else {
                                     selectedTools.plus(tool.name)
                                     viewModel.selectCrisisTool(tool)
                                 }
-                                viewModel.updateCrisisTool(tool)
                             }
                         )
                     }

--- a/app/src/main/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationScreen.kt
+++ b/app/src/main/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationScreen.kt
@@ -1,6 +1,5 @@
 package com.devmob.alaya.ui.screen.crisis_registration
 
-
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
@@ -34,7 +33,6 @@ import androidx.compose.material.icons.outlined.SentimentVeryDissatisfied
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
@@ -87,11 +85,6 @@ fun CrisisRegistrationScreen(
     var selectedBodySensations by remember { mutableStateOf<Map<String, Intensity>>(emptyMap()) }
     val emotions by viewModel.emotions.observeAsState(emptyList())
     var selectedEmotions by remember { mutableStateOf<Set<String>>(emptySet()) }
-
-    // Carga el último registro cuando se inicializa la pantalla
-    LaunchedEffect(Unit) {
-        viewModel.loadLastCrisisDetails()
-    }
 
     BackHandler {
         when(screenState.value?.currentStep){

--- a/app/src/main/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationScreen.kt
+++ b/app/src/main/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationScreen.kt
@@ -52,7 +52,6 @@ import com.devmob.alaya.components.SegmentedProgressBar
 import com.devmob.alaya.domain.model.CrisisBodySensation
 import com.devmob.alaya.domain.model.CrisisEmotion
 import com.devmob.alaya.domain.model.CrisisPlace
-import com.devmob.alaya.domain.model.CrisisTimeDetails
 import com.devmob.alaya.domain.model.CrisisTool
 import com.devmob.alaya.domain.model.Intensity
 import com.devmob.alaya.ui.components.CrisisRegisterIconButton
@@ -68,7 +67,6 @@ import com.devmob.alaya.ui.theme.ColorText
 import com.devmob.alaya.ui.theme.ColorWhite
 import com.devmob.alaya.utils.NavUtils
 
-
 @Composable
 fun CrisisRegistrationScreen(
     viewModel: CrisisRegistrationViewModel,
@@ -76,7 +74,6 @@ fun CrisisRegistrationScreen(
     onFinishedRegistration: () -> Unit,
     navController: NavHostController,
 ) {
-
     val screenState = viewModel.screenState.observeAsState()
     val shouldShowExitModal = viewModel.shouldShowExitModal
     val messageTextSize = 30.sp
@@ -90,8 +87,6 @@ fun CrisisRegistrationScreen(
     var selectedBodySensations by remember { mutableStateOf<Map<String, Intensity>>(emptyMap()) }
     val emotions by viewModel.emotions.observeAsState(emptyList())
     var selectedEmotions by remember { mutableStateOf<Set<String>>(emptySet()) }
-
-    val crisisTimeDetails by viewModel.crisisTimeDetails.observeAsState(CrisisTimeDetails())
 
     // Carga el último registro cuando se inicializa la pantalla
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationViewModel.kt
+++ b/app/src/main/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationViewModel.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -19,7 +18,7 @@ import com.devmob.alaya.domain.model.CrisisTool
 import com.devmob.alaya.domain.model.FirebaseResult
 import com.devmob.alaya.domain.model.Intensity
 import com.devmob.alaya.domain.model.util.toDB
-import com.devmob.alaya.ui.screen.crisis_registration.GridElementsRepository.returnAvailableTools
+import com.devmob.alaya.ui.screen.crisis_registration.GridElementsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.util.Date
@@ -79,7 +78,7 @@ class CrisisRegistrationViewModel(
                             )
                         )
                     }
-                    val availableTools = returnAvailableTools()
+                    val availableTools = GridElementsRepository.returnAvailableTools()
 
                     val selectedCrisisTools = result.tools.mapNotNull { toolId ->
                         availableTools.find { it.id == toolId }

--- a/app/src/test/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/devmob/alaya/ui/screen/crisis_registration/CrisisRegistrationViewModelTest.kt
@@ -164,7 +164,7 @@ class CrisisRegistrationViewModelTest {
     }
 
     @Test
-    fun `when updateCrisisBodySensation is called, then update list`() {
+    fun `when selectCrisisBodySensation is called, then update list`() {
         val mockkIcon = mockk<ImageVector>()
         val bodySensation1 = CrisisBodySensation("Desmayo", mockkIcon)
         val bodySensation2 = CrisisBodySensation("Calor", mockkIcon)
@@ -174,25 +174,23 @@ class CrisisRegistrationViewModelTest {
     }
 
     @Test
-    fun `when updateCrisisEmotion is called, then update list`() {
+    fun `when selectCrisisEmotion is called, then update list`() {
         val mockkIcon = mockk<ImageVector>()
         val emotion1 = CrisisEmotion("Angustia", mockkIcon)
         val emotion2 = CrisisEmotion("Tristeza", mockkIcon)
-        viewModel.updateCrisisEmotion(emotion1)
-        viewModel.updateCrisisEmotion(emotion2)
+        viewModel.selectCrisisEmotion(emotion1)
+        viewModel.selectCrisisEmotion(emotion2)
         assertEquals(2, viewModel.screenState.value?.crisisDetails?.emotionList?.size)
     }
 
     @Test
-    fun `when updateCrisisTool is called, then update list`() {
+    fun `when selectCrisisTool is called, then update list`() {
         val mockkIcon = mockk<ImageVector>()
-        val observer = Observer<CrisisRegistrationScreenState> {}
-        val tool1 = CrisisTool("Meditacion", "", mockkIcon)
-        val tool2 = CrisisTool("Respiracion", "", mockkIcon)
-        viewModel.screenState.observeForever(observer)
-        viewModel.updateCrisisTool(tool1)
-        viewModel.updateCrisisTool(tool2)
-        assertEquals(0, viewModel.screenState.value?.crisisDetails?.toolList?.size)
+        val tool1 = CrisisTool("Autoafirmaciones", "Autoafirmaciones", mockkIcon)
+        val tool2 = CrisisTool("Controlar la respiración", "Respiracion", mockkIcon)
+        viewModel.selectCrisisTool(tool1)
+        viewModel.selectCrisisTool(tool2)
+        assertEquals(2, viewModel.screenState.value?.crisisDetails?.toolList?.size)
     }
 
     @Test


### PR DESCRIPTION
Soluciona el error que dejaba seleccionando y deseleccionando constantemente las tools en el registro de crisis.
Soluciona que se pueda guardar en firestore el registro.